### PR TITLE
Adapt iOS13 and iPhone11

### DIFF
--- a/Classes/AppDelegate.m
+++ b/Classes/AppDelegate.m
@@ -135,23 +135,14 @@
                 }
                 else
                 {
-                    self.visibleAlert = [[UIAlertView alloc] initWithTitle:title
-                                                                   message:message
-                                                                  delegate:self
-                                                         cancelButtonTitle:button
-                                                         otherButtonTitles:nil];
-                    [self.visibleAlert show];
+                    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
+                    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:button style:UIAlertActionStyleCancel handler:^(UIAlertAction * _Nonnull action) {
+                        
+                    }];
+                    [alert addAction:cancelAction];
                 }
             }
         });
-    }
-}
-
-- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
-{
-    if (alertView == self.visibleAlert)
-    {
-        self.visibleAlert = nil;
     }
 }
 

--- a/Classes/Concurrency-Info.plist
+++ b/Classes/Concurrency-Info.plist
@@ -34,6 +34,8 @@
 	<string>1.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Main</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Classes/Currencies.m
+++ b/Classes/Currencies.m
@@ -89,7 +89,7 @@ static NSString *const UpdateURL = @"http://themoneyconverter.com/rss-feed/EUR/r
 {
     NSURL *URL = [NSURL URLWithString:UpdateURL];
     NSURLRequest *request = [NSURLRequest requestWithURL:URL];
-    [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         NSDictionary *xmlDict = [NSDictionary dictionaryWithXMLData:data];
         if (xmlDict)
         {
@@ -130,6 +130,8 @@ static NSString *const UpdateURL = @"http://themoneyconverter.com/rss-feed/EUR/r
         
         if (block) block();
     }];
+    
+    [task resume];
 }
 
 - (void)update

--- a/Classes/Currencies.m
+++ b/Classes/Currencies.m
@@ -89,8 +89,7 @@ static NSString *const UpdateURL = @"http://themoneyconverter.com/rss-feed/EUR/r
 {
     NSURL *URL = [NSURL URLWithString:UpdateURL];
     NSURLRequest *request = [NSURLRequest requestWithURL:URL];
-    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue mainQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
-        
+    [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         NSDictionary *xmlDict = [NSDictionary dictionaryWithXMLData:data];
         if (xmlDict)
         {

--- a/Classes/Main.storyboard
+++ b/Classes/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="vXZ-lx-hvc">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
     </dependencies>
     <scenes>
         <!--Cube Controller-->

--- a/Classes/NumberPad.xib
+++ b/Classes/NumberPad.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment version="1792" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/Concurrency.xcodeproj/project.pbxproj
+++ b/Concurrency.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -496,7 +497,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -528,7 +529,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -542,6 +543,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Classes/Concurrency-Prefix.pch";
 				INFOPLIST_FILE = "Classes/Concurrency-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_NAME = Concurrency;
 				WRAPPER_EXTENSION = app;
 			};
@@ -555,6 +557,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Classes/Concurrency-Prefix.pch";
 				INFOPLIST_FILE = "Classes/Concurrency-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				PRODUCT_NAME = Concurrency;
 				WRAPPER_EXTENSION = app;
 			};

--- a/Concurrency.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Concurrency.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Libraries/BaseModel/BaseModel.m
+++ b/Libraries/BaseModel/BaseModel.m
@@ -62,12 +62,12 @@ static const NSUInteger BMStringDescriptionMaxLength = 16;
 
 - (id)BM_propertyListRepresentation
 {
-    return [NSKeyedArchiver archivedDataWithRootObject:self];
+    return [NSKeyedArchiver archivedDataWithRootObject:self requiringSecureCoding:YES error:nil];
 }
 
 - (id)BM_JSONRepresentation
 {
-    return [[NSKeyedArchiver archivedDataWithRootObject:self] BM_JSONRepresentation];
+    return [[NSKeyedArchiver archivedDataWithRootObject:self requiringSecureCoding:YES error:nil] BM_JSONRepresentation];
 }
 
 - (id)BM_objectFromPropertyListOrJSON
@@ -161,7 +161,7 @@ static const NSUInteger BMStringDescriptionMaxLength = 16;
     if ([object respondsToSelector:@selector(objectForKey:)] && object[@"$archiver"])
     {
         //unarchive object
-        return [NSKeyedUnarchiver unarchiveObjectWithData:self];
+        return [NSKeyedUnarchiver unarchivedObjectOfClass:[self class] fromData:self error:nil];
     }
     return self;
 }
@@ -971,7 +971,7 @@ static const NSUInteger BMStringDescriptionMaxLength = 16;
     {
         case BMFileFormatKeyedArchive:
         {
-            data = [NSKeyedArchiver archivedDataWithRootObject:self];
+            data = [NSKeyedArchiver archivedDataWithRootObject:self requiringSecureCoding:YES error:nil];
             break;
         }
         case BMFileFormatXMLPropertyList:

--- a/Libraries/iCarousel/iCarousel.m
+++ b/Libraries/iCarousel/iCarousel.m
@@ -1504,26 +1504,14 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
         
 #ifdef ICAROUSEL_IOS
         
-        [UIView beginAnimations:nil context:nil];
-        [UIView setAnimationDuration:0.1];
-        [UIView setAnimationDelegate:itemView.superview];
-        [UIView setAnimationDidStopSelector:@selector(removeFromSuperview)];
         [self performSelector:@selector(queueItemView:) withObject:itemView afterDelay:0.1];
         itemView.superview.layer.opacity = 0.0;
-        [UIView commitAnimations];
-        
-        [UIView beginAnimations:nil context:nil];
-        [UIView setAnimationDelay:0.1];
-        [UIView setAnimationDuration:INSERT_DURATION];
-        [UIView setAnimationDelegate:self];
-        [UIView setAnimationDidStopSelector:@selector(depthSortViews)];
         [self removeViewAtIndex:index];
         _numberOfItems --;
         _wrapEnabled = !![self valueForOption:iCarouselOptionWrap withDefault:_wrapEnabled];
         [self updateNumberOfVisibleItems];
         _scrollOffset = self.currentItemIndex;
         [self didScroll];
-        [UIView commitAnimations];
         
 #else
 		[NSAnimationContext beginGrouping];
@@ -1587,12 +1575,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
 
 #ifdef ICAROUSEL_IOS
         
-        [UIView beginAnimations:nil context:nil];
-        [UIView setAnimationDuration:INSERT_DURATION];
-        [UIView setAnimationDelegate:self];
-        [UIView setAnimationDidStopSelector:@selector(didScroll)];
         [self transformItemViews];
-        [UIView commitAnimations];
         
 #else
 		[NSAnimationContext beginGrouping];

--- a/Libraries/iRate/iRate.m
+++ b/Libraries/iRate/iRate.m
@@ -690,7 +690,7 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
         }
         
         NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:iTunesServiceURL] cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:REQUEST_TIMEOUT];
-        [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        NSURLSessionTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
             NSInteger statusCode = ((NSHTTPURLResponse *)response).statusCode;
             if (data && statusCode == 200)
             {
@@ -799,6 +799,8 @@ static NSString *const iRateMacAppStoreURLFormat = @"macappstore://itunes.apple.
             //finished
             checking = NO;
         }];
+        
+        [task resume];
     }
 }
 

--- a/Libraries/iVersion/iVersion.m
+++ b/Libraries/iVersion/iVersion.m
@@ -762,7 +762,7 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
             NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:iTunesServiceURL]
                                                      cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
                                                  timeoutInterval:REQUEST_TIMEOUT];
-            [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+            NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
                 NSInteger statusCode = ((NSHTTPURLResponse *)response).statusCode;
                 if (data && statusCode == 200)
                 {
@@ -901,7 +901,7 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
                             }
                             
                             NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:self.remoteVersionsPlistURL] cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:REQUEST_TIMEOUT];
-                            [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                            NSURLSessionTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
                                 if (data)
                                 {
                                     NSDictionary *plistVersions = nil;
@@ -938,6 +938,8 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
                                     NSLog(@"iVersion was unable to download the user-specified release notes");
                                 }
                             }];
+                            
+                            [task resume];
                         }
                     }
                     else if (statusCode >= 400)
@@ -953,6 +955,8 @@ static NSString *const iVersionMacAppStoreURLFormat = @"macappstore://itunes.app
                 [self performSelectorOnMainThread:@selector(setLastChecked:) withObject:[NSDate date] waitUntilDone:YES];
                 [self performSelectorOnMainThread:@selector(downloadedVersionsData) withObject:nil waitUntilDone:YES];
             }];
+            
+            [task resume];
         }
     }
 }


### PR DESCRIPTION
`UIAlertView` is deprecated in iOS9, so I replace it with `UIAlertController`. Similarly, `NSURLConnection` is replaced with `NSURLSession`.
I also delete methods about `UIAlertViewDelegate` and the app seems to work fine, but I'm not sure whether this will lead to function missing, which I don't notice.